### PR TITLE
Update screen_display.cpp

### DIFF
--- a/code_editor/src/screen_display.cpp
+++ b/code_editor/src/screen_display.cpp
@@ -569,4 +569,14 @@ screen_line(
 			&& col + 1 < endcol
 			&& (*mb_off2cells)(off_to, max_off_to) > 1)
 		{
+ // Writing a single-cell character over a double-cell
+		    // character: need to redraw the next cell.
+		    ScreenLines[off_to + 1] = 0;
+		    redraw_next = TRUE;
+		}
+		else if (char_cells == 2
+			&& col + 2 < endcol
+			&& (*mb_off2cells)(off_to, max_off_to) == 1
+			&& (*mb_off2cells)(off_to + 1, max_off_to) > 1)
+		{
 


### PR DESCRIPTION
Fix rendering of single-cell characters over double-cell characters

- Clear the next cell when writing a single-cell character over a double-cell character to avoid rendering artifacts.
- Ensure proper handling of adjacent characters with different cell widths by checking the cell size of the current and next characters.
- Set a flag to redraw the next cell when necessary.