### PR TITLE
Create deb.h

### DIFF
--- a/code_editor/src/deb.h
+++ b/code_editor/src/deb.h
@@ -1,0 +1,60 @@
+#ifndef NBDEBUG_H
+#define NBDEBUG_H
+
+#ifdef NBDEBUG
+
+# ifndef ASSERT
+#  define ASSERT(c) \
+    if (!(c)) \
+    { \
+	fprintf(stderr, "Assertion failed: line %d, file %s\n", \
+		__LINE__, __FILE__); \
+	fflush(stderr); \
+	abort(); \
+    }
+# endif
+
+# define nbdebug(a) nbdbg a
+
+# define NB_TRACE		0x00000001
+# define NB_TRACE_VERBOSE	0x00000002
+# define NB_TRACE_COLONCMD	0x00000004
+# define NB_PRINT		0x00000008
+# define NB_DEBUG_ALL		0xffffffff
+
+# define NBDLEVEL(flags)	(nb_debug != NULL && (nb_dlevel & (flags)))
+
+# define NBDEBUG_TRACE	1
+
+typedef enum {
+		WT_ENV = 1,		// look for env var if set
+		WT_WAIT,		// look for ~/.gvimwait if set
+		WT_STOP			// look for ~/.gvimstop if set
+} WtWait;
+
+
+void		 nbdbg(char *, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
+
+void nbdebug_wait(u_int wait_flags, char *wait_var, u_int wait_secs);
+void nbdebug_log_init(char *log_var, char *level_var);
+
+extern FILE	*nb_debug;
+extern u_int	 nb_dlevel;		// nb_debug verbosity level
+
+#else		// not NBDEBUG
+
+# ifndef ASSERT
+#  define ASSERT(c)
+# endif
+
+/*
+ * The following 3 stubs are needed because a macro cannot be used because of
+ * the variable number of arguments.
+ */
+
+void
+nbdbg(
+	char		*fmt,
+	...)
+{
+}


### PR DESCRIPTION
Add debugging framework for conditional logging and assertions

- Define `NBDEBUG` macro to enable/disable debugging features at compile time.
- Implement `ASSERT` macro for runtime assertions, logging errors and aborting on failure.
- Add `nbdebug` macro and `nbdbg` function for flexible debug logging with variadic arguments.
- Introduce debug levels (`NB_TRACE`, `NB_PRINT`, etc.) to control verbosity of debug output.
- Provide `nbdebug_wait` function to pause execution for debugging purposes.
- Add `nbdebug_log_init` function to initialize debug logging based on environment variables.
- Define stubs for non-debug builds to ensure no performance overhead in release mode.