### PR TITLE
Create python.cpp

### DIFF
--- a/code_editor/src/rt.cpp
+++ b/code_editor/src/rt.cpp
@@ -1,0 +1,47 @@
+#include <editor.h>
+#include <limits.h>
+
+#if defined(MSWIN) && defined(HAVE_FCNTL_H)
+# undef HAVE_FCNTL_H
+#endif
+
+#ifdef _DEBUG
+# undef _DEBUG
+#endif
+
+#ifdef F_BLANK
+# undef F_BLANK
+#endif
+
+#ifdef HAVE_DUP
+# undef HAVE_DUP
+#endif
+#ifdef HAVE_STRFTIME
+# undef HAVE_STRFTIME
+#endif
+#ifdef HAVE_STRING_H
+# undef HAVE_STRING_H
+#endif
+#ifdef HAVE_PUTENV
+# undef HAVE_PUTENV
+#endif
+#ifdef HAVE_STDARG_H
+# undef HAVE_STDARG_H   // Python's config.h defines it as well.
+#endif
+#ifdef _POSIX_C_SOURCE  // defined in feature.h
+# undef _POSIX_C_SOURCE
+#endif
+#ifdef _XOPEN_SOURCE
+# undef _XOPEN_SOURCE	// pyconfig.h defines it as well.
+#endif
+
+#define PY_SSIZE_T_CLEAN
+
+#ifdef Py_LIMITED_API
+# define USE_LIMITED_API // Using Python 3 limited ABI
+#endif
+
+#include <Python.h>
+
+#undef main // Defined in python.h - aargh
+#undef HAVE_FCNTL_H // Clash with os_win32.h


### PR DESCRIPTION
Fix preprocessor configuration for Python C API compatibility

- Undefine conflicting macros (`HAVE_FCNTL_H`, `_DEBUG`, `F_BLANK`, etc.) to avoid clashes with system headers and Python's configuration.
- Define `PY_SSIZE_T_CLEAN` to ensure consistent use of `Py_ssize_t` in Python C API functions.
- Handle Python's limited API by defining `USE_LIMITED_API` when `Py_LIMITED_API` is enabled.
- Undefine `main` and `HAVE_FCNTL_H` to prevent conflicts with `Python.h` and `os_win32.h`.
- Add platform-specific handling for Windows (`MSWIN`) to undefine `HAVE_FCNTL_H`.

